### PR TITLE
Add Reference to TaskParams

### DIFF
--- a/task.go
+++ b/task.go
@@ -209,6 +209,7 @@ type TaskParams struct {
 	RecurrenceFactor    int        `json:"recurrence_factor,string,omitempty"`
 	RecurrenceTimeframe int        `json:"recurrence_timeframe,string,omitempty"`
 	RecurrenceBaseDate  int        `json:"recurrence_basedate,string,omitempty"`
+	Reference           string     `json:"reference"`
 	Tags                []string   `json:"tags,omitempty"`
 	DateStarted         *time.Time `json:"date_started,omitempty"`
 }


### PR DESCRIPTION
It looks like the library can load the `reference` field for a `Task`, but it is missing for the `TaskParams`, so it can never be updated by the library.

I appreciate your work on this!